### PR TITLE
Feature/blob support

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -38,6 +38,21 @@ export function extractRequestFiles(request) {
         return
       }
 
+      if (typeof Blob !== 'undefined' && node[key] instanceof Blob) {
+        files.push({
+          variablesPath: `variables${path}.${key}`,
+          file: node[key]
+        })
+
+        // Delete the file from the request variables. It gets repopulated on
+        // the server by apollo-upload-server middleware. If an array item it
+        // must be deleted without reindexing the array.
+        delete node[key]
+
+        // No deeper recursion
+        return
+      }
+
       // Convert file list to an array so recursion can reach the files
       if (typeof FileList !== 'undefined' && node[key] instanceof FileList)
         node[key] = Array.from(node[key])

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -20,25 +20,11 @@ export function extractRequestFiles(request) {
       // Check if the node is a file
       if (
         (typeof File !== 'undefined' && node[key] instanceof File) ||
-        node[key] instanceof ReactNativeFile
+        node[key] instanceof ReactNativeFile ||
+        (typeof Blob !== 'undefined' && node[key] instanceof Blob)
       ) {
         // Extract the file and it's original path in the GraphQL input
         // variables for later transport as a multipart form field.
-        files.push({
-          variablesPath: `variables${path}.${key}`,
-          file: node[key]
-        })
-
-        // Delete the file from the request variables. It gets repopulated on
-        // the server by apollo-upload-server middleware. If an array item it
-        // must be deleted without reindexing the array.
-        delete node[key]
-
-        // No deeper recursion
-        return
-      }
-
-      if (typeof Blob !== 'undefined' && node[key] instanceof Blob) {
         files.push({
           variablesPath: `variables${path}.${key}`,
           file: node[key]

--- a/src/network-interface.js
+++ b/src/network-interface.js
@@ -17,11 +17,7 @@ export class UploadHTTPFetchNetworkInterface extends HTTPFetchNetworkInterface {
         const formData = new FormData()
         formData.append('operations', JSON.stringify(operation))
         files.forEach(({ variablesPath, file }) => {
-          if (typeof Blob !== 'undefined' && file instanceof Blob) {
-            formData.append(variablesPath, file, file.name)
-          } else {
-            formData.append(variablesPath, file)
-          }
+          formData.append(variablesPath, file, file.name)
         })
 
         // Send request

--- a/src/network-interface.js
+++ b/src/network-interface.js
@@ -16,9 +16,13 @@ export class UploadHTTPFetchNetworkInterface extends HTTPFetchNetworkInterface {
         // Build the form
         const formData = new FormData()
         formData.append('operations', JSON.stringify(operation))
-        files.forEach(({ variablesPath, file }) =>
-          formData.append(variablesPath, file)
-        )
+        files.forEach(({ variablesPath, file }) => {
+          if (typeof Blob !== 'undefined' && file instanceof Blob) {
+            formData.append(variablesPath, file, file.name)
+          } else {
+            formData.append(variablesPath, file)
+          }
+        })
 
         // Send request
         return fetch(this._uri, {


### PR DESCRIPTION
Added check for blobs to use an added name attribute as the filename in form data.
If no filename is supplied, the upload still works just with a default name of 'blob'.